### PR TITLE
Fix broken Videos footer link on v3.silex.me

### DIFF
--- a/_site/en/index.html
+++ b/_site/en/index.html
@@ -384,7 +384,7 @@ window.addEventListener('load', function() {
     
   <a href="https://short.silex.me/code" id="irpxxx" class="footer__item" target="_blank">Source code</a>
   <a href="http://docs.silex.me/" id="irpxxx" class="footer__item" target="_blank">Documentation</a>
-  <a href="https://video.silex.me/my-library/video-playlists" id="irpxxx" class="footer__item" target="_blank">Videos</a>
+  <a href="https://video.silex.me/c/silex_en/video-playlists" id="irpxxx" class="footer__item" target="_blank">Videos</a>
   <a href="https://short.silex.me/roadmap" id="irpxxx" class="footer__item" target="_blank">Roadmap</a>
   <a href="https://short.silex.me/contribute" id="irpxxx" class="footer__item" target="_blank">Contribute</a></div>
   <div id="isucae" style="min-height:100px;" class="footer__column"><h3 href="" id="ipa5zg" class="footer__item">Articles and reviews</h3>

--- a/collections/settings/en.json
+++ b/collections/settings/en.json
@@ -86,7 +86,7 @@
         },
         {
           "label": "Videos",
-          "url": "https://video.silex.me/my-library/video-playlists",
+          "url": "https://video.silex.me/c/silex_en/video-playlists",
           "target": "_blank"
         },
         {

--- a/collections/settings/fr.json
+++ b/collections/settings/fr.json
@@ -88,7 +88,7 @@
         },
         {
           "label": "Vidéos",
-          "url": "https://video.silex.me/my-library/video-playlists",
+          "url": "https://video.silex.me/c/silex_en/video-playlists",
           "target": "_blank"
         },
         {

--- a/collections/settings/fr.json
+++ b/collections/settings/fr.json
@@ -88,7 +88,7 @@
         },
         {
           "label": "Vidéos",
-          "url": "https://video.silex.me/c/silex_en/video-playlists",
+          "url": "https://video.silex.me/c/silex_fr/video-playlists",
           "target": "_blank"
         },
         {


### PR DESCRIPTION
Fixes the broken "Videos" footer link.

Updated the link to the correct playlist URL.

Closes [#1646](https://github.com/silexlabs/Silex/issues/1646)