### PR TITLE
fix: use HTTPS URL for nested dashboard submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "silex/websites/dashboard"]
 	path = silex/websites/dashboard
-	url = git@gitlab.com:silexlabs/dashboard-silexv3.git
+	url = https://gitlab.com/silexlabs/dashboard-silexv3.git


### PR DESCRIPTION
## Problem

The nested `silex/websites/dashboard` submodule pointed to an **SSH** URL (`git@gitlab.com:silexlabs/dashboard-silexv3.git`), which requires a registered key, so recursive clones fail for contributors without GitLab SSH credentials:

```
git@gitlab.com: Permission denied (publickey).
```

This breaks the contributor setup reported in silexlabs/Silex#1756.

## Fix

Switch the submodule to the **public HTTPS** URL so anonymous recursive clones work out of the box. Contributors who prefer SSH for pushing can override locally via `git config url."git@gitlab.com:".insteadOf "https://gitlab.com/"`.

Refs silexlabs/Silex#1756